### PR TITLE
detect l2/r2 as joypad motion

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -381,6 +381,10 @@ func _convert_joypad_motion_to_path(axis: int):
 			path = "joypad/l_stick"
 		JOY_ANALOG_RX, JOY_ANALOG_RY:
 			path = "joypad/r_stick"
+		JOY_L2:
+			path = "joypad/lt"
+		JOY_R2:
+			path = "joypad/rt"
 		_:
 			return ""
 	return Mapper._convert_joypad_path(path, _settings.joypad_fallback)


### PR DESCRIPTION
Just a suggestion to add detection of L2 and R2 as motion as well instead of only as buttons. I.e. if they are added to the Input Map as a Joy Axis [this comparison is true](https://github.com/Ev1lbl0w/controller_icons/blob/master/addons/controller_icons/ControllerIcons.gd#L121) and I think a lot of controllers do actually have support for this.

In my case it fixes the missing symbol and hopefully does not break anything for others.